### PR TITLE
bugfix with initializer for neural net params missing the bias row

### DIFF
--- a/ex4/ex4.py
+++ b/ex4/ex4.py
@@ -133,8 +133,8 @@ raw_input("Program paused. Press Enter to continue...")
 
 print 'Initializing Neural Network Parameters ...'
 
-initial_Theta1 = randInitializeWeights(input_layer_size, hidden_layer_size)
-initial_Theta2 = randInitializeWeights(hidden_layer_size, num_labels)
+initial_Theta1 = randInitializeWeights(input_layer_size+1, hidden_layer_size)
+initial_Theta2 = randInitializeWeights(hidden_layer_size+1, num_labels)
 
 # Unroll parameters
 initial_nn_params = np.hstack((initial_Theta1.T.ravel(), initial_Theta2.T.ravel()))


### PR DESCRIPTION
I beg your pardon if I am mistaken, but I think the random initializer for the neural network in `ex4.py` is missing an extra row (the bias term)...

Hence the pull request.
